### PR TITLE
Allow failing report to be edited to success

### DIFF
--- a/src/main/java/nl/nn/testtool/test/webapp/SimpleRerunner.java
+++ b/src/main/java/nl/nn/testtool/test/webapp/SimpleRerunner.java
@@ -1,5 +1,7 @@
 package nl.nn.testtool.test.webapp;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import lombok.Setter;
@@ -16,6 +18,35 @@ public class SimpleRerunner implements Rerunner {
 	@Override
 	public String rerun(String correlationId, Report originalReport,
 			SecurityContext securityContext, ReportRunner reportRunner) {
+		if(! rerunSpecialReport(correlationId, originalReport, securityContext, reportRunner)) {
+			rerunDefault(correlationId, originalReport, securityContext, reportRunner);
+		}
+		return null;
+	}
+
+	/**
+	 * Rerun a report that we want to investigate in the ladybug-frontend Cypress tests.
+	 * For some reports, we want to edit them during the tests such that they will succeed
+	 * on rerun.
+	 * 
+	 * @param correlationId
+	 * @param originalReport
+	 * @param securityContext
+	 * @param reportRunner
+	 * @return
+	 */
+	private boolean rerunSpecialReport(String correlationId, Report originalReport,
+			SecurityContext securityContext, ReportRunner reportRunner) {
+		if(new HashSet<>(Arrays.asList("name", "otherName")).contains(originalReport.getName())) {
+			testTool.startpoint(correlationId, "sourceClassName", "name", "Hello Original World!");
+			testTool.endpoint(correlationId, "sourceClassName", "name", "Goodbye Original World!");
+			return true;
+		}
+		return false;
+	}
+
+	private void rerunDefault(String correlationId, Report originalReport,
+			SecurityContext securityContext, ReportRunner reportRunner) {
 		List<Checkpoint> checkpoints = originalReport.getCheckpoints();
 		String name = checkpoints.get(0).getName();
 		String message = checkpoints.get(0).getMessage();
@@ -27,7 +58,5 @@ public class SimpleRerunner implements Rerunner {
 		name = checkpoints.get(checkpoints.size() - 1).getName();
 		message = checkpoints.get(checkpoints.size() - 1).getMessage();
 		testTool.endpoint(correlationId, this.getClass().getName(), name, message);
-		return null;
 	}
-
 }

--- a/src/main/resources/springTestToolTestWebapp.xml
+++ b/src/main/resources/springTestToolTestWebapp.xml
@@ -185,7 +185,7 @@
 	<bean name="reportsTreeCellRenderer" class="nl.nn.testtool.echo2.reports.ReportsTreeCellRenderer"/>
 
 	<bean name="reportXmlTransformer" class="nl.nn.testtool.transform.ReportXmlTransformer">
-		<property name="xsltResource" value="nl/nn/testtool/test/junit/transformReport.xslt"/>
+		<property name="xsltResource" value="transformReport.xslt"/>
 	</bean>
 
 	<bean name="rerunner" class="nl.nn.testtool.test.webapp.SimpleRerunner" autowire="byName"/>

--- a/src/main/resources/transformReport.xslt
+++ b/src/main/resources/transformReport.xslt
@@ -1,0 +1,35 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+	<xsl:output method="xml" indent="yes" omit-xml-declaration="yes"/>
+	<xsl:strip-space elements="*"/>
+	
+	<xsl:template match="/Report">
+		<xsl:copy>
+			<xsl:apply-templates select="node()|@*"/>
+		</xsl:copy>
+	</xsl:template>
+
+	<xsl:template match="@CorrelationId">
+		<xsl:attribute name="CorrelationId">
+			<xsl:value-of select="concat('Not empty: ', string-length(.) &gt; 0)"/>
+		</xsl:attribute>
+	</xsl:template>
+
+	<xsl:template match="@StartTime">
+		<xsl:attribute name="StartTime">
+			<xsl:value-of select="concat('Original length: ', string-length(.))"/>
+		</xsl:attribute>
+	</xsl:template>
+
+	<xsl:template match="@EndTime">
+		<xsl:attribute name="EndTime">
+			<xsl:value-of select="concat('Original length: ', string-length(.))"/>
+		</xsl:attribute>
+	</xsl:template>
+	
+	<xsl:template match="node()|@*">
+		<xsl:copy>
+			<xsl:apply-templates select="node()|@*"/>
+		</xsl:copy>
+	</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
- Have new report transformation XSLT that does not compare correlation id length.
- For two records in index.jsp, change the update behavior.